### PR TITLE
Add support for Amazon Ireland

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Furthermore, not every site has it's own translation for the warning message.
 		<li>amazon.de</li>
 		<li>amazon.fr</li>
 		<li>amazon.it</li>
+		<li>amazon.ie</li>
 		<li>amazon.es</li>
 		<li>amazon.nl</li>
 		<li>amazon.com.br</li>

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"manifest_version": 3,
 	"name": "AmznShipWarn",
-	"version": "1.1.4",
+	"version": "1.1.5",
 	"description": "Adds a warning to the Amazon page if the item is not shipped by Amazon.",
 	"homepage_url": "https://github.com/MrMinemeet/AmznShipWarn",
 	"content_scripts": [
@@ -14,6 +14,7 @@
 				"https://*.amazon.de/*",
 				"https://*.amazon.fr/*",
 				"https://*.amazon.it/*",
+				"https://*.amazon.ie/*",
 				"https://*.amazon.es/*",
 				"https://*.amazon.nl/*",
 				"https://*.amazon.com.br/*",


### PR DESCRIPTION
Ireland now has Amazon.ie since ~18th of March

https://www.aboutamazon.eu/news/retail/amazon-launches-amazon-ie-in-ireland